### PR TITLE
Use https URL for git checkout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,7 @@ Available commands:
 Once done, you can clone this repo:
 
 ----
-git clone git@github.com:alvarosanchez/ratpack-101.git
+git clone https://github.com/alvarosanchez/ratpack-101.git
 ----
 
 You will find each exercise's template files on each `exNN` folder. Solution is always inside a `solution` folder.


### PR DESCRIPTION
Cloning the Git repo using the git@github.com URL only works with a pre-setup git access. Using the https URL allows access for non-Github users as well.
